### PR TITLE
V0.4.0 - Remove ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,29 +54,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_compile_definitions(DUCKDB_USE_STANDARD_ASSERT=1)
 endif()
 
-# ccache options
-find_program(CCACHE_PROGRAM ccache)
-if(CCACHE_PROGRAM)
-if(NOT DEFINED ENV{OPAQUE_CCACHE_ACCESS_KEY})
-message(WARNING "ccache found, but network cache access key not set. Please set the OPAQUE_CCACHE_ACCESS_KEY environment variable.")
-endif()
-set(C_LAUNCHER "${CCACHE_PROGRAM}")
-set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
-message(STATUS "Found launcher ${CXX_LAUNCHER}")
-add_compile_options("-fdebug-prefix-map=$PWD=.") # enables useful caching for debug builds
-# The .in files are template files for ccache launchers.
-# CMake populates them with the correct cmake command, and they
-# use the appropriate environment variable to allow ccache to
-# communicate with the redis cache.
-configure_file("${CMAKE_CURRENT_LIST_DIR}/scripts/launch-c.in" "${CMAKE_CURRENT_BINARY_DIR}/launch-c" FILE_PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE GROUP_READ GROUP_EXECUTE WORLD_EXECUTE WORLD_READ)
-configure_file("${CMAKE_CURRENT_LIST_DIR}/scripts/launch-cxx.in" "${CMAKE_CURRENT_BINARY_DIR}/launch-cxx" FILE_PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE GROUP_READ GROUP_EXECUTE WORLD_EXECUTE WORLD_READ)
-# Set the custom launchers (ccache + settings) for C and C++ compilers
-set(CMAKE_C_COMPILER_LAUNCHER "${CMAKE_CURRENT_BINARY_DIR}/launch-c")
-set(CMAKE_CXX_COMPILER_LAUNCHER "${CMAKE_CURRENT_BINARY_DIR}/launch-cxx")
-else()
-message(WARNING "ccache not found: build times will not benefit from caching.")
-endif()
-
 # Determine install paths
 set(INSTALL_LIB_DIR
     lib

--- a/ccache.conf
+++ b/ccache.conf
@@ -1,1 +1,0 @@
-sloppiness=locale,system_headers

--- a/scripts/launch-c.in
+++ b/scripts/launch-c.in
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# set basedir to the folder containing the repo
-export CCACHE_BASEDIR="$(git rev-parse --show-toplevel)/.."
-# set config path to the Opaque ccache config
-export CCACHE_CONFIGPATH="$(git rev-parse --show-toplevel)/ccache.conf"
-# set redis url (contains access key)
-export CCACHE_SECONDARY_STORAGE="redis://$OPAQUE_CCACHE_ACCESS_KEY@opaque-buildcache.redis.cache.windows.net"
-exec "${C_LAUNCHER}" "$@"

--- a/scripts/launch-cxx.in
+++ b/scripts/launch-cxx.in
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# set basedir to the folder containing the repo
-export CCACHE_BASEDIR="$(git rev-parse --show-toplevel)/.."
-# set config path to the Opaque ccache config
-export CCACHE_CONFIGPATH="$(git rev-parse --show-toplevel)/ccache.conf"
-# set redis url (contains access key)
-export CCACHE_SECONDARY_STORAGE="redis://$OPAQUE_CCACHE_ACCESS_KEY@opaque-buildcache.redis.cache.windows.net"
-exec "${CXX_LAUNCHER}" "$@"


### PR DESCRIPTION
As discussed on Slack, it turns out that having a ccache config in this file overrides the ccache config from the agent building this from source. Since we currently can't package this library standalone, it makes no sense to keep this config around, and it dramatically slows down the client and SQL build processes. This PR removes all of the ccache config previous added to this repo.

To verify that this worked, I clean built the client twice with local caching disabled (note: I changed the source branch to this feature branch, but once merged, this change will be automatic for the main repo builds). This resulted in a very fast build the second time, with the following ccache statistics:
```
Cacheable calls:    945 /  945 (100.0%)
  Hits:             944 /  945 (99.89%)
    Direct:         940 /  944 (99.58%)
    Preprocessed:     4 /  944 ( 0.42%)
  Misses:             1 /  945 ( 0.11%)
Local storage:
  Cache size (GB): 0.81 / 5.00 (16.25%)
  Hits:               0
  Misses:             0
Remote storage:
  Hits:             944 /  945 (99.89%)
  Misses:             1 /  945 ( 0.11%)
```